### PR TITLE
Adds scrollingStickyHeader prop and disables bg scaling on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The `ParallaxScrollView` component adds a few additional properties, as describe
 | `renderStickyHeader` | `func` | No | This renders an optional sticky header that will stick to the top of view when parallax header scrolls up. |
 | `stickyHeaderHeight` | `number` | If `renderStickyHeader` is used | If `renderStickyHeader` is set, then its height must be specified. |
 | `contentContainerStyle` | `object` | No | These styles will be applied to the scroll view content container which wraps all of the child views. (same as for [ScrollView](https://facebook.github.io/react-native/docs/scrollview.html#contentcontainerstyle)) |
+| `scrollingStickyHeader` | `bool` | No | This causes the sticky header to scroll into view. If set to false the sticky header will only fade in. |
 
 ## Latest changes
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import {
-  Animated,
-  Dimensions,
-  Platform,
-  ScrollView,
-  View
+	Animated,
+	Dimensions,
+	Platform,
+	ScrollView,
+	View
 } from 'react-native';
 
 const styles = require('./styles');
@@ -23,317 +23,324 @@ const renderEmpty = () => <View/>;
 // an error when serializing style on view inside inspector.
 // See: https://github.com/jaysoo/react-native-parallax-scroll-view/issues/23
 const interpolate = (value, opts) => {
-  const x = value.interpolate(opts);
-  x.toJSON = () => x.__getValue();
-  return x;
+	const x = value.interpolate(opts);
+	x.toJSON = () => x.__getValue();
+	return x;
 };
 
 // Properties accepted by `ParallaxScrollView`.
 const IPropTypes = {
-  backgroundColor: string,
-  backgroundScrollSpeed: number,
-  fadeOutForeground: bool,
-  fadeOutBackground: bool,
-  contentBackgroundColor: string,
-  onChangeHeaderVisibility: func,
-  parallaxHeaderHeight: number.isRequired,
-  renderBackground: func,
-  renderFixedHeader: func,
-  renderForeground: func,
-  renderScrollComponent: func,
-  renderStickyHeader: func,
-  stickyHeaderHeight: number,
-  contentContainerStyle: View.propTypes.style,
-  scrollingStickyHeader: bool,
+	backgroundColor: string,
+	backgroundScrollSpeed: number,
+	fadeOutForeground: bool,
+	fadeOutBackground: bool,
+	contentBackgroundColor: string,
+	onChangeHeaderVisibility: func,
+	parallaxHeaderHeight: number.isRequired,
+	renderBackground: func,
+	renderFixedHeader: func,
+	renderForeground: func,
+	renderScrollComponent: func,
+	renderStickyHeader: func,
+	stickyHeaderHeight: number,
+	contentContainerStyle: View.propTypes.style,
+	scrollingStickyHeader: bool,
 };
 
 class ParallaxScrollView extends Component {
-  constructor(props) {
-    super(props);
-    if (props.renderStickyHeader && !props.stickyHeaderHeight) {
-      console.warn('Property `stickyHeaderHeight` must be set if `renderStickyHeader` is used.');
-    }
-    if (props.renderParallaxHeader !== renderEmpty && !props.renderForeground) {
-      console.warn('Property `renderParallaxHeader` is deprecated. Use `renderForeground` instead.');
-    }
-    this.state = {
-      scrollY: new Animated.Value(0),
-      viewHeight: window.height,
-      viewWidth: window.width
-    };
-    this._footerComponent = { setNativeProps() {} }; // Initial stub
-    this._footerHeight = 0;
-  }
+	constructor(props) {
+		super(props);
+		if (props.renderStickyHeader && !props.stickyHeaderHeight) {
+			console.warn('Property `stickyHeaderHeight` must be set if `renderStickyHeader` is used.');
+		}
+		if (props.renderParallaxHeader !== renderEmpty && !props.renderForeground) {
+			console.warn('Property `renderParallaxHeader` is deprecated. Use `renderForeground` instead.');
+		}
+		this.state = {
+			scrollY: new Animated.Value(0),
+			viewHeight: window.height,
+			viewWidth: window.width
+		};
+		this._footerComponent = { setNativeProps() {} }; // Initial stub
+		this._footerHeight = 0;
+	}
 
-  render() {
-    const {
-      backgroundColor,
-      backgroundScrollSpeed,
-      children,
-      contentBackgroundColor,
-      fadeOutForeground,
-      fadeOutBackground,
-      parallaxHeaderHeight,
-      renderBackground,
-      renderFixedHeader,
-      renderForeground,
-      renderParallaxHeader,
-      renderScrollComponent,
-      renderStickyHeader,
-      stickyHeaderHeight,
-      style,
-      contentContainerStyle,
-      scrollingStickyHeader,
-      ...scrollViewProps
-    } = this.props;
+	render() {
+		const {
+			backgroundColor,
+			backgroundScrollSpeed,
+			children,
+			contentBackgroundColor,
+			fadeOutForeground,
+			fadeOutBackground,
+			parallaxHeaderHeight,
+			renderBackground,
+			renderFixedHeader,
+			renderForeground,
+			renderParallaxHeader,
+			renderScrollComponent,
+			renderStickyHeader,
+			stickyHeaderHeight,
+			style,
+			contentContainerStyle,
+			scrollingStickyHeader,
+			...scrollViewProps
+		} = this.props;
 
-    const background = this._renderBackground({ fadeOutBackground, backgroundScrollSpeed, backgroundColor, parallaxHeaderHeight, stickyHeaderHeight, renderBackground });
-    const foreground = this._renderForeground({ fadeOutForeground, parallaxHeaderHeight, stickyHeaderHeight, renderForeground: renderForeground || renderParallaxHeader });
-    const bodyComponent = this._wrapChildren(children, { contentBackgroundColor, stickyHeaderHeight, contentContainerStyle });
-    const footerSpacer = this._renderFooterSpacer({ contentBackgroundColor });
-    const maybeStickyHeader = this._maybeRenderStickyHeader({ parallaxHeaderHeight, stickyHeaderHeight, backgroundColor, renderFixedHeader, renderStickyHeader, scrollingStickyHeader });
-    const scrollElement = renderScrollComponent(scrollViewProps);
+		const background = this._renderBackground({ fadeOutBackground, backgroundScrollSpeed, backgroundColor, parallaxHeaderHeight, stickyHeaderHeight, renderBackground });
+		const foreground = this._renderForeground({ fadeOutForeground, parallaxHeaderHeight, stickyHeaderHeight, renderForeground: renderForeground || renderParallaxHeader });
+		const bodyComponent = this._wrapChildren(children, { contentBackgroundColor, stickyHeaderHeight, contentContainerStyle });
+		const footerSpacer = this._renderFooterSpacer({ contentBackgroundColor });
+		const maybeStickyHeader = this._maybeRenderStickyHeader({ parallaxHeaderHeight, stickyHeaderHeight, backgroundColor, renderFixedHeader, renderStickyHeader, scrollingStickyHeader });
+		const scrollElement = renderScrollComponent(scrollViewProps);
 
-    return (
-      <View style={[style, styles.container]}
-            onLayout={(e) => this._maybeUpdateViewDimensions(e)}>
-        { background }
-        {
-          React.cloneElement(scrollElement, {
-              ref: SCROLLVIEW_REF,
-              style: [styles.scrollView, scrollElement.props.style],
-              scrollEventThrottle: 16,
-              onScroll: this._onScroll.bind(this),
-            },
-            foreground,
-            bodyComponent,
-            footerSpacer
-          )
-        }
-        { maybeStickyHeader }
-      </View>
-    );
-  }
+		return (
+            <View style={[style, styles.container]}
+                  onLayout={(e) => this._maybeUpdateViewDimensions(e)}>
+				{ background }
+				{
+					React.cloneElement(scrollElement, {
+							ref: SCROLLVIEW_REF,
+							style: [styles.scrollView, scrollElement.props.style],
+							scrollEventThrottle: 16,
+							onScroll: this._onScroll.bind(this),
+						},
+						foreground,
+						bodyComponent,
+						footerSpacer
+					)
+				}
+				{ maybeStickyHeader }
+            </View>
+		);
+	}
 
   /*
    * Expose `ScrollView` API so this component is composable with any component that expects a `ScrollView`.
    */
-  getScrollResponder() {
-    return this.refs[SCROLLVIEW_REF].getScrollResponder();
-  }
-  getScrollableNode() {
-    return this.getScrollResponder().getScrollableNode();
-  }
-  getInnerViewNode() {
-    return this.getScrollResponder().getInnerViewNode();
-  }
-  scrollTo(...args) {
-    this.getScrollResponder().scrollTo(...args);
-  }
-  setNativeProps(props) {
-    this.refs[SCROLLVIEW_REF].setNativeProps(props);
-  }
+	getScrollResponder() {
+		return this.refs[SCROLLVIEW_REF].getScrollResponder();
+	}
+	getScrollableNode() {
+		return this.getScrollResponder().getScrollableNode();
+	}
+	getInnerViewNode() {
+		return this.getScrollResponder().getInnerViewNode();
+	}
+	scrollTo(...args) {
+		this.getScrollResponder().scrollTo(...args);
+	}
+	setNativeProps(props) {
+		this.refs[SCROLLVIEW_REF].setNativeProps(props);
+	}
 
   /*
    * Private helpers
    */
 
-  _onScroll(e) {
-    const {
-      parallaxHeaderHeight,
-      stickyHeaderHeight,
-      onChangeHeaderVisibility,
-      onScroll: prevOnScroll = () => {}
-      } = this.props;
+	_onScroll(e) {
+		const {
+			parallaxHeaderHeight,
+			stickyHeaderHeight,
+			onChangeHeaderVisibility,
+			onScroll: prevOnScroll = () => {}
+		} = this.props;
 
-    const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight);
+		const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight);
 
-    this._maybeUpdateScrollPosition(e);
+		this._maybeUpdateScrollPosition(e);
 
-    if (e.nativeEvent.contentOffset.y >= p) {
-      onChangeHeaderVisibility(false);
-    } else {
-      onChangeHeaderVisibility(true);
-    }
+		if (e.nativeEvent.contentOffset.y >= p) {
+			onChangeHeaderVisibility(false);
+		} else {
+			onChangeHeaderVisibility(true);
+		}
 
-    prevOnScroll(e);
-  }
+		prevOnScroll(e);
+	}
 
-  // This optimizes the state update of current scrollY since we don't need to
-  // perform any updates when user has scrolled past the pivot point.
-  _maybeUpdateScrollPosition(e) {
-    const { parallaxHeaderHeight, stickyHeaderHeight } = this.props;
-    const { scrollY } = this.state;
-    const { nativeEvent: { contentOffset: { y: offsetY } } } = e;
-    const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight);
+	// This optimizes the state update of current scrollY since we don't need to
+	// perform any updates when user has scrolled past the pivot point.
+	_maybeUpdateScrollPosition(e) {
+		const { parallaxHeaderHeight, stickyHeaderHeight } = this.props;
+		const { scrollY } = this.state;
+		const { nativeEvent: { contentOffset: { y: offsetY } } } = e;
+		const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight);
 
-    if (offsetY <= p || scrollY._value <= p) {
-      scrollY.setValue(offsetY);
-    }
-  }
+		if (offsetY <= p || scrollY._value <= p) {
+			scrollY.setValue(offsetY);
+		}
+	}
 
-  _maybeUpdateViewDimensions(e) {
-    const { nativeEvent: { layout: { width, height} } } = e;
+	_maybeUpdateViewDimensions(e) {
+		const { nativeEvent: { layout: { width, height} } } = e;
 
-    if (width !== this.state.viewWidth || height !== this.state.viewHeight) {
-      this.setState({
-        viewWidth: width,
-        viewHeight: height
-      });
-    }
-  }
+		if (width !== this.state.viewWidth || height !== this.state.viewHeight) {
+			this.setState({
+				viewWidth: width,
+				viewHeight: height
+			});
+		}
+	}
 
-  _renderBackground({ fadeOutBackground, backgroundScrollSpeed, backgroundColor, parallaxHeaderHeight, stickyHeaderHeight, renderBackground }) {
-    const { viewWidth, viewHeight, scrollY } = this.state;
-    const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight);
-    return (
-      <Animated.View
-        style={[styles.backgroundImage, {
-            backgroundColor: backgroundColor,
-            height: parallaxHeaderHeight,
-            width: viewWidth,
-            opacity: fadeOutBackground
-                     ? interpolate(scrollY, {
-                      inputRange: [0, p *  (1/2), p * (3/4), p],
-                      outputRange: [1, 0.3, 0.1, 0],
-                      extrapolate: 'clamp'
-                    })
-                    : 1,
-            transform: [{
-              translateY: interpolate(scrollY, {
-                inputRange: [0, p],
-                outputRange: [0, -(p / backgroundScrollSpeed)],
-                extrapolateRight: 'extend',
-                extrapolateLeft: 'clamp'
-              })
-            }, Platform.OS === 'ios' ? {
-              scale: interpolate(scrollY, {
-                inputRange: [-viewHeight, 0],
-                outputRange: [5, 1],
-                extrapolate: 'clamp'
-              })
-            } : null]
-          }]}>
-        <View>
-          { renderBackground() }
-        </View>
-      </Animated.View>
-    );
-  }
+	_renderBackground({ fadeOutBackground, backgroundScrollSpeed, backgroundColor, parallaxHeaderHeight, stickyHeaderHeight, renderBackground }) {
+		const { viewWidth, viewHeight, scrollY } = this.state;
+		const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight);
+		const transform = [{
+			translateY: interpolate(scrollY, {
+				inputRange: [0, p],
+				outputRange: [0, -(p / backgroundScrollSpeed)],
+				extrapolateRight: 'extend',
+				extrapolateLeft: 'clamp'
+			})
+		}];
+		if (Platform.OS === 'ios') {
+			transform.push({
+				scale: interpolate(scrollY, {
+					inputRange: [-viewHeight, 0],
+					outputRange: [5, 1],
+					extrapolate: 'clamp'
+				})
+			});
+		}
+		return (
+            <Animated.View
+                style={[styles.backgroundImage, {
+					backgroundColor: backgroundColor,
+					height: parallaxHeaderHeight,
+					width: viewWidth,
+					opacity: fadeOutBackground
+						? interpolate(scrollY, {
+							inputRange: [0, p *  (1/2), p * (3/4), p],
+							outputRange: [1, 0.3, 0.1, 0],
+							extrapolate: 'clamp'
+						})
+						: 1,
+					transform,
+				}]}>
+              <View>
+				  { renderBackground() }
+              </View>
+            </Animated.View>
+		);
+	}
 
-  _renderForeground({ fadeOutForeground, parallaxHeaderHeight, stickyHeaderHeight, renderForeground }) {
-    const { scrollY } = this.state;
-    const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight);
-    return (
-      <View style={styles.parallaxHeaderContainer}>
-        <Animated.View
-          style={[styles.parallaxHeader, {
-                  height: parallaxHeaderHeight,
-                  opacity: fadeOutForeground
-                     ? interpolate(scrollY, {
-                      inputRange: [0, p *  (1/2), p * (3/4), p],
-                      outputRange: [1, 0.3, 0.1, 0],
-                      extrapolate: 'clamp'
-                    })
-                    : 1
-                }]}>
-            <View style={{ height: parallaxHeaderHeight }}>
-              { renderForeground() }
+	_renderForeground({ fadeOutForeground, parallaxHeaderHeight, stickyHeaderHeight, renderForeground }) {
+		const { scrollY } = this.state;
+		const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight);
+		return (
+            <View style={styles.parallaxHeaderContainer}>
+              <Animated.View
+                  style={[styles.parallaxHeader, {
+					  height: parallaxHeaderHeight,
+					  opacity: fadeOutForeground
+						  ? interpolate(scrollY, {
+							  inputRange: [0, p *  (1/2), p * (3/4), p],
+							  outputRange: [1, 0.3, 0.1, 0],
+							  extrapolate: 'clamp'
+						  })
+						  : 1
+				  }]}>
+                <View style={{ height: parallaxHeaderHeight }}>
+					{ renderForeground() }
+                </View>
+              </Animated.View>
             </View>
-        </Animated.View>
-      </View>
-    );
-  }
+		);
+	}
 
-  _wrapChildren(children, { contentBackgroundColor, stickyHeaderHeight, contentContainerStyle }) {
-    const { viewHeight } = this.state;
-    const containerStyles = [{backgroundColor: contentBackgroundColor}];
+	_wrapChildren(children, { contentBackgroundColor, stickyHeaderHeight, contentContainerStyle }) {
+		const { viewHeight } = this.state;
+		const containerStyles = [{backgroundColor: contentBackgroundColor}];
 
-    if(contentContainerStyle)
-      containerStyles.push(contentContainerStyle);
+		if(contentContainerStyle)
+			containerStyles.push(contentContainerStyle);
 
-    return (
-      <View
-        style={containerStyles}
-        onLayout={e => {
-                // Adjust the bottom height so we can scroll the parallax header all the way up.
-                const { nativeEvent: { layout: { height } } } = e;
-                const footerHeight = Math.max(0, viewHeight - height - stickyHeaderHeight);
-                if (this._footerHeight !== footerHeight) {
-                  this._footerComponent.setNativeProps({ style: { height: footerHeight }});
-                  this._footerHeight = footerHeight;
-                }
-              }}>
-        { children }
-      </View>
-    );
-  }
+		return (
+            <View
+                style={containerStyles}
+                onLayout={e => {
+					// Adjust the bottom height so we can scroll the parallax header all the way up.
+					const { nativeEvent: { layout: { height } } } = e;
+					const footerHeight = Math.max(0, viewHeight - height - stickyHeaderHeight);
+					if (this._footerHeight !== footerHeight) {
+						this._footerComponent.setNativeProps({ style: { height: footerHeight }});
+						this._footerHeight = footerHeight;
+					}
+				}}>
+				{ children }
+            </View>
+		);
+	}
 
-  _renderFooterSpacer({ contentBackgroundColor }) {
-    return (
-      <View ref={ref => this._footerComponent = ref } style={{ backgroundColor: contentBackgroundColor }}/>
-    );
-  }
+	_renderFooterSpacer({ contentBackgroundColor }) {
+		return (
+            <View ref={ref => this._footerComponent = ref } style={{ backgroundColor: contentBackgroundColor }}/>
+		);
+	}
 
-  _maybeRenderStickyHeader({ parallaxHeaderHeight, stickyHeaderHeight, backgroundColor, renderFixedHeader, renderStickyHeader, scrollingStickyHeader }) {
-    const { viewWidth, scrollY } = this.state;
-    if (renderStickyHeader || renderFixedHeader) {
-      const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight);
-      return (
-        <View style={[styles.stickyHeader, { width: viewWidth, ...(stickyHeaderHeight ? { height: stickyHeaderHeight } : null ) }]}>
-          {
-            renderStickyHeader
-              ? (
-                <Animated.View
-                  style={{
-                  backgroundColor: backgroundColor,
-                  height: stickyHeaderHeight,
-                  opacity: interpolate(scrollY, {
-                    inputRange: [0, p],
-                    outputRange: [0, 1],
-                    extrapolate: 'clamp'
-                  })
-                }}>
-                  <Animated.View
-                    style={ scrollingStickyHeader ? {
-                    transform: [{
-                      translateY: interpolate(scrollY, {
-                        inputRange: [0, p],
-                        outputRange: [stickyHeaderHeight, 0],
-                        extrapolate: 'clamp'
-                      })
-                    }]
-                  } : null }>
-                    { renderStickyHeader() }
-                  </Animated.View>
-                </Animated.View>
-              )
-              : null
-          }
-          { renderFixedHeader && renderFixedHeader() }
-        </View>
-      );
-    } else {
-      return null;
-    }
-  }
+	_maybeRenderStickyHeader({ parallaxHeaderHeight, stickyHeaderHeight, backgroundColor, renderFixedHeader, renderStickyHeader, scrollingStickyHeader }) {
+		const { viewWidth, scrollY } = this.state;
+		if (renderStickyHeader || renderFixedHeader) {
+			const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight);
+			const stickyHeader = scrollingStickyHeader ? (
+                    <Animated.View
+                        style={{
+							transform: [{
+								translateY: interpolate(scrollY, {
+									inputRange: [0, p],
+									outputRange: [stickyHeaderHeight, 0],
+									extrapolate: 'clamp'
+								})
+							}]
+						}}>
+						{this.renderStickyHeader()}
+                    </Animated.View>
+				) : renderStickyHeader();
+			return (
+                <View style={[styles.stickyHeader, { width: viewWidth, ...(stickyHeaderHeight ? { height: stickyHeaderHeight } : null ) }]}>
+					{
+						renderStickyHeader
+							? (
+                                <Animated.View
+                                    style={{
+										backgroundColor: backgroundColor,
+										height: stickyHeaderHeight,
+										opacity: interpolate(scrollY, {
+											inputRange: [0, p],
+											outputRange: [0, 1],
+											extrapolate: 'clamp'
+										})
+									}}>
+									{ stickyHeader }
+                                </Animated.View>
+							)
+							: null
+					}
+					{ renderFixedHeader && renderFixedHeader() }
+                </View>
+			);
+		} else {
+			return null;
+		}
+	}
 }
 
 ParallaxScrollView.propTypes = IPropTypes;
 
 ParallaxScrollView.defaultProps = {
-  backgroundScrollSpeed: 5,
-  backgroundColor: '#000',
-  contentBackgroundColor: '#fff',
-  fadeOutForeground: true,
-  onChangeHeaderVisibility: () => {},
-  renderScrollComponent: props => <ScrollView {...props}/>,
-  renderBackground: renderEmpty,
-  renderParallaxHeader: renderEmpty, // Deprecated (will be removed in 0.18.0)
-  renderForeground: null,
-  stickyHeaderHeight: 0,
-  contentContainerStyle: null,
-  scrollingStickyheader: true,
+	backgroundScrollSpeed: 5,
+	backgroundColor: '#000',
+	contentBackgroundColor: '#fff',
+	fadeOutForeground: true,
+	onChangeHeaderVisibility: () => {},
+	renderScrollComponent: props => <ScrollView {...props}/>,
+	renderBackground: renderEmpty,
+	renderParallaxHeader: renderEmpty, // Deprecated (will be removed in 0.18.0)
+	renderForeground: null,
+	stickyHeaderHeight: 0,
+	contentContainerStyle: null,
+	scrollingStickyheader: true,
 };
 
 module.exports = ParallaxScrollView;

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import {
   Animated,
   Dimensions,
+  Platform,
   ScrollView,
   View
 } from 'react-native';
@@ -42,7 +43,8 @@ const IPropTypes = {
   renderScrollComponent: func,
   renderStickyHeader: func,
   stickyHeaderHeight: number,
-  contentContainerStyle: View.propTypes.style
+  contentContainerStyle: View.propTypes.style,
+  scrollingStickyHeader: bool,
 };
 
 class ParallaxScrollView extends Component {
@@ -81,6 +83,7 @@ class ParallaxScrollView extends Component {
       stickyHeaderHeight,
       style,
       contentContainerStyle,
+      scrollingStickyHeader,
       ...scrollViewProps
     } = this.props;
 
@@ -88,7 +91,7 @@ class ParallaxScrollView extends Component {
     const foreground = this._renderForeground({ fadeOutForeground, parallaxHeaderHeight, stickyHeaderHeight, renderForeground: renderForeground || renderParallaxHeader });
     const bodyComponent = this._wrapChildren(children, { contentBackgroundColor, stickyHeaderHeight, contentContainerStyle });
     const footerSpacer = this._renderFooterSpacer({ contentBackgroundColor });
-    const maybeStickyHeader = this._maybeRenderStickyHeader({ parallaxHeaderHeight, stickyHeaderHeight, backgroundColor, renderFixedHeader, renderStickyHeader });
+    const maybeStickyHeader = this._maybeRenderStickyHeader({ parallaxHeaderHeight, stickyHeaderHeight, backgroundColor, renderFixedHeader, renderStickyHeader, scrollingStickyHeader });
     const scrollElement = renderScrollComponent(scrollViewProps);
 
     return (
@@ -203,13 +206,13 @@ class ParallaxScrollView extends Component {
                 extrapolateRight: 'extend',
                 extrapolateLeft: 'clamp'
               })
-            }, {
+            }, Platform.OS === 'ios' ? {
               scale: interpolate(scrollY, {
                 inputRange: [-viewHeight, 0],
                 outputRange: [5, 1],
                 extrapolate: 'clamp'
               })
-            }]
+            } : null]
           }]}>
         <View>
           { renderBackground() }
@@ -272,7 +275,7 @@ class ParallaxScrollView extends Component {
     );
   }
 
-  _maybeRenderStickyHeader({ parallaxHeaderHeight, stickyHeaderHeight, backgroundColor, renderFixedHeader, renderStickyHeader }) {
+  _maybeRenderStickyHeader({ parallaxHeaderHeight, stickyHeaderHeight, backgroundColor, renderFixedHeader, renderStickyHeader, scrollingStickyHeader }) {
     const { viewWidth, scrollY } = this.state;
     if (renderStickyHeader || renderFixedHeader) {
       const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight);
@@ -292,7 +295,7 @@ class ParallaxScrollView extends Component {
                   })
                 }}>
                   <Animated.View
-                    style={{
+                    style={ scrollingStickyHeader ? {
                     transform: [{
                       translateY: interpolate(scrollY, {
                         inputRange: [0, p],
@@ -300,7 +303,7 @@ class ParallaxScrollView extends Component {
                         extrapolate: 'clamp'
                       })
                     }]
-                  }}>
+                  } : null }>
                     { renderStickyHeader() }
                   </Animated.View>
                 </Animated.View>
@@ -329,7 +332,8 @@ ParallaxScrollView.defaultProps = {
   renderParallaxHeader: renderEmpty, // Deprecated (will be removed in 0.18.0)
   renderForeground: null,
   stickyHeaderHeight: 0,
-  contentContainerStyle: null
+  contentContainerStyle: null,
+  scrollingStickyheader: true,
 };
 
 module.exports = ParallaxScrollView;


### PR DESCRIPTION
This will address issue #37 by adding the `scrollingStickyHeader` prop which defaults to true. If disabled, the sticky header will only fade in, making for a smoother transition.

Additionally, this disables the background scaling for Android devices since Android listviews cannot scroll beyond their normal range. This prevents the occasional scale "popping" on Android when scrolling down fast.