### PR TITLE
Add optional styles as props for header containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,10 @@ The `ParallaxScrollView` component adds a few additional properties, as describe
 | `stickyHeaderHeight` | `number` | If `renderStickyHeader` is used | If `renderStickyHeader` is set, then its height must be specified. |
 | `contentContainerStyle` | `object` | No | These styles will be applied to the scroll view content container which wraps all of the child views. (same as for [ScrollView](https://facebook.github.io/react-native/docs/scrollview.html#contentcontainerstyle)) |
 | `outputScaleValue` | `number` | No | The value for the scale interpolation output value, default `5` |
-
+| `parallaxHeaderContainerStyle` | `object` | No | These styles will be applied to the parallax header view content container  |
+| `parallaxHeaderStyle` | `object` | No | These styles will be applied to the parallax header view content  |
+| `backgroundImageStyle` | `object` | No | These styles will be applied to the background image header view content  |
+| `stickyHeaderStyle` | `object` | No | These styles will be applied to the sticky headerStyle view content  |
 
 ## Latest changes
 

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,11 @@ const IPropTypes = {
 	renderStickyHeader: func,
 	stickyHeaderHeight: number,
 	contentContainerStyle: View.propTypes.style,
-	outputScaleValue: number
+	outputScaleValue: number,
+	parallaxHeaderContainerStyle: View.propTypes.style,
+	parallaxHeaderStyle: View.propTypes.style,
+	backgroundImageStyle: View.propTypes.style,
+	stickyHeaderStyle: View.propTypes.style
 }
 
 class ParallaxScrollView extends Component {
@@ -232,6 +236,7 @@ class ParallaxScrollView extends Component {
 			<Animated.View
 				style={[
 					styles.backgroundImage,
+					((this.props.backgroundImageStyle)?this.props.backgroundImageStyle:null),
 					{
 						backgroundColor: backgroundColor,
 						height: parallaxHeaderHeight,
@@ -279,10 +284,14 @@ class ParallaxScrollView extends Component {
 		const { scrollY } = this
 		const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight)
 		return (
-			<View style={styles.parallaxHeaderContainer}>
+			<View style={[
+				styles.parallaxHeaderContainer,
+				(this.props.parallaxHeaderContainerStyle)?this.props.parallaxHeaderContainerStyle:null
+			]}>
 				<Animated.View
 					style={[
 						styles.parallaxHeader,
+						((this.props.parallaxHeaderStyle)?this.props.parallaxHeaderStyle:null),
 						{
 							height: parallaxHeaderHeight,
 							opacity: fadeOutForeground
@@ -359,6 +368,7 @@ class ParallaxScrollView extends Component {
 				<View
 					style={[
 						styles.stickyHeader,
+						((this.props.stickyHeaderStyle)?this.props.stickyHeaderStyle:null),
 						{
 							width: viewWidth,
 							...(stickyHeaderHeight ? { height: stickyHeaderHeight } : null)
@@ -417,7 +427,11 @@ ParallaxScrollView.defaultProps = {
 	renderForeground: null,
 	stickyHeaderHeight: 0,
 	contentContainerStyle: null,
-	outputScaleValue: 5
+	outputScaleValue: 5,
+	parallaxHeaderContainerStyle: null,
+	parallaxHeaderStyle: null,
+	backgroundImageStyle: null,
+	stickyHeaderStyle: null
 }
 
 module.exports = ParallaxScrollView


### PR DESCRIPTION
This optional props styles can be necessary to bypass the
{overflow:hidden} attributes set by default in each header styles.

If for instance, a button is placed between the top static header and the scrollable content, it is cropped by this overflow: hidden.


