### PR TITLE
Fix prop type reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
 		"android"
 	],
 	"author": "Jack Hsu",
-	"license": "ISC"
+	"license": "ISC",
+	"dependencies": {
+		"prop-types": "^15.6.0"
+	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import { Animated, Dimensions, ScrollView, View } from 'react-native'
 
 const styles = require('./styles')
 
-const { bool, func, number, string } = React.PropTypes
+import { bool, func, number, string } from 'prop-types'
 
 const window = Dimensions.get('window')
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Animated, Dimensions, ScrollView, View } from 'react-native'
+import { Animated, Dimensions, ScrollView, View, ViewPropTypes } from 'react-native'
 
 const styles = require('./styles')
 
@@ -37,7 +37,7 @@ const IPropTypes = {
 	renderScrollComponent: func,
 	renderStickyHeader: func,
 	stickyHeaderHeight: number,
-	contentContainerStyle: View.propTypes.style,
+	contentContainerStyle: ViewPropTypes.style,
 	outputScaleValue: number
 }
 


### PR DESCRIPTION
Latest versions of React no longer have PropTypes, must import from prop-types