### PR TITLE
Adjust background scale to prevent foreground from scaling out

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -255,7 +255,7 @@ class ParallaxScrollView extends Component {
 							{
 								scale: interpolate(scrollY, {
 									inputRange: [-viewHeight, 0],
-									outputRange: [outputScaleValue, 1],
+									outputRange: [outputScaleValue * 1.5, 1],
 									extrapolate: 'clamp'
 								})
 							}


### PR DESCRIPTION
There's an issue where `ParallaxScrollView` doesn't scale the background enough on scroll to cover the new height, leading to lower layers of an app's UI to show up (such as a gray background) and the foreground to seemingly go outside the bounds of the background. This looks really bad, but adjusting the scaling by a factor of >= 1.4 seemed to work, though there might need to be a more dynamic value for different images.

[Here's an example of the bug](https://imgur.com/a/NDfBxqA).