### PR TITLE
Move sticky header out of the way so foreground touches work

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -371,6 +371,13 @@ class ParallaxScrollView extends Component {
 	}) {
 		const { viewWidth } = this.state
 		const { scrollY } = this
+
+    const translateY = interpolate(scrollY, {
+      inputRange: [0, stickyHeaderHeight],
+      outputRange: [-stickyHeaderHeight, 0],
+      extrapolate: 'clamp'
+    })
+
 		if (renderStickyHeader || renderFixedHeader) {
 			const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight)
 			return (
@@ -379,6 +386,7 @@ class ParallaxScrollView extends Component {
 						styles.stickyHeader,
 						{
 							width: viewWidth,
+              transform: [{ translateY }],
 							...(stickyHeaderHeight ? { height: stickyHeaderHeight } : null)
 						}
 					]}
@@ -388,6 +396,7 @@ class ParallaxScrollView extends Component {
 							style={{
 								backgroundColor: backgroundColor,
 								height: stickyHeaderHeight,
+                transform: [{ translateY }],
 								opacity: interpolate(scrollY, {
 									inputRange: [0, p],
 									outputRange: [0, 1],


### PR DESCRIPTION
Touchable items in the foreground are currently blocked when they are positioned over the sticky header. 

This change animates the sticky header to move it out of the way before the user scrolls up, allowing presses to happen in that area.