### PR TITLE
Hide animation overflow

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -3,7 +3,8 @@ const StyleSheet = require('react-native').StyleSheet;
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: 'transparent'
+    backgroundColor: 'transparent',
+    overflow: 'hidden'
   },
   parallaxHeaderContainer: {
     backgroundColor: 'transparent',


### PR DESCRIPTION
Add overflow hidden to container to prevent the animation of the image overflowing over the scrollview