### PR TITLE
Parallax height

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,8 @@ export interface ParallaxScrollViewProps {
     outputScaleValue?: number;
     style?: any;
     parallaxHeaderHeight?: number;
+    resetScroll: bool,
+	resetScrollSuccessfull: func
 }
 
 export class RenderBackgroundParams {

--- a/src/index.js
+++ b/src/index.js
@@ -184,7 +184,7 @@ class ParallaxScrollView extends Component {
 			onScroll: prevOnScroll = () => { }
 		} = this.props
 		this.props.scrollEvent && this.props.scrollEvent(e)
-		const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight)
+		const p = pivotPoint(parallaxHeaderHeight, stickyHeaderHeight + 55)
 
 		// This optimization wont run, since we update the animation value directly in onScroll event
 		// this._maybeUpdateScrollPosition(e)

--- a/src/index.js
+++ b/src/index.js
@@ -178,7 +178,7 @@ class ParallaxScrollView extends Component {
    * Private helpers
    */
 
-	componentWillUpdate(prevProps) {
+  	componentDidUpdate(prevProps) {
 		if (prevProps.resetScroll !== this.props.resetScroll) {
 			this.getScrollResponder().scrollTo({x: 0, y: 0, animated: false})
 			this.props.resetScrollSuccessfull()

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,9 @@ const IPropTypes = {
 	renderStickyHeader: func,
 	stickyHeaderHeight: number,
 	contentContainerStyle: ViewPropTypes.style,
-	outputScaleValue: number
+	outputScaleValue: number,
+	resetScroll: bool,
+	resetScrollSuccessfull: func
 }
 
 class ParallaxScrollView extends Component {
@@ -175,6 +177,13 @@ class ParallaxScrollView extends Component {
 	/*
    * Private helpers
    */
+
+	componentWillUpdate(prevProps) {
+		if (prevProps.resetScroll !== this.props.resetScroll) {
+			this.getScrollResponder().scrollTo({x: 0, y: 0, animated: false})
+			this.props.resetScrollSuccessfull()
+		}
+	}
 
 	_onScroll(e) {
 		const {
@@ -436,7 +445,9 @@ ParallaxScrollView.defaultProps = {
 	renderForeground: null,
 	stickyHeaderHeight: 0,
 	contentContainerStyle: null,
-	outputScaleValue: 5
+	outputScaleValue: 5,
+	resetScroll: false,
+	resetScrollSuccessfull: () => {}
 }
 
 module.exports = ParallaxScrollView


### PR DESCRIPTION
React-native parallax header height:
Reset scrollview scroll position to initial state.
Added 50 pixel height to meet the design(tile visibility) & overlapping parallax navigation bar.
 