### PR TITLE
Fix getScrollResponder() function which is not working in react-nativ…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -157,7 +157,7 @@ class ParallaxScrollView extends Component {
    * Expose `ScrollView` API so this component is composable with any component that expects a `ScrollView`.
    */
 	getScrollResponder() {
-		return this.refs[SCROLLVIEW_REF]._component.getScrollResponder()
+		return this.refs[SCROLLVIEW_REF].getScrollResponder()
 	}
 	getScrollableNode() {
 		return this.getScrollResponder().getScrollableNode()


### PR DESCRIPTION
Fix getScrollResponder() function which is not working in react-native version 0.62.2.
![scrollview _component undefined](https://user-images.githubusercontent.com/20240740/82629451-5bbaa080-9c22-11ea-9e96-4fe1d8c39c61.png)
