### PR TITLE
Fix : undefined is not an object (evaluating 'this.refs[SCROLLVIEW_REF]._component.getScrollResponder')

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -157,7 +157,7 @@ class ParallaxScrollView extends Component {
    * Expose `ScrollView` API so this component is composable with any component that expects a `ScrollView`.
    */
 	getScrollResponder() {
-		return this.refs[SCROLLVIEW_REF]._component.getScrollResponder()
+		return this.refs[SCROLLVIEW_REF].getScrollResponder()
 	}
 	getScrollableNode() {
 		return this.getScrollResponder().getScrollableNode()


### PR DESCRIPTION
On React-Native 0.63^, scrollTo method is not available while using parallaxscrollview, due to this bug scrolling behaviour control is not possible.