### PR TITLE
Use deprecated-react-native-prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	"author": "Jack Hsu",
 	"license": "ISC",
 	"dependencies": {
+		"deprecated-react-native-prop-types": "^2.3.0",
 		"prop-types": "^15.6.0"
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
-import { Animated, Dimensions, View, ViewPropTypes } from 'react-native'
+import { Animated, Dimensions, View } from 'react-native'
+import { ViewPropTypes } from 'deprecated-react-native-prop-types'
 
 const styles = require('./styles')
 


### PR DESCRIPTION
### Platforms affected
All

### What does this PR do?
RN 0.68 has deprecated and will eventually remove `ViewPropTypes` ([see post](https://github.com/facebook/react-native/issues/21342)). This adds the `deprecated-react-native-prop-types` package and uses that instead.

### What testing has been done on this change?
Local testing, to ensure the deprecation warning has been removed.