### PR TITLE
Fix resolution of prop types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,12 +41,12 @@ const IPropTypes = {
 	renderScrollComponent: func,
 	renderStickyHeader: func,
 	stickyHeaderHeight: number,
-	contentContainerStyle: View.propTypes.style,
+	contentContainerStyle: ViewPropTypes.style,
 	outputScaleValue: number,
-	parallaxHeaderContainerStyle: View.propTypes.style,
-	parallaxHeaderStyle: View.propTypes.style,
-	backgroundImageStyle: View.propTypes.style,
-	stickyHeaderStyle: View.propTypes.style
+	parallaxHeaderContainerStyle: ViewPropTypes.style,
+	parallaxHeaderStyle: ViewPropTypes.style,
+	backgroundImageStyle: ViewPropTypes.style,
+	stickyHeaderStyle: ViewPropTypes.style
 }
 
 class ParallaxScrollView extends Component {


### PR DESCRIPTION
I merged a few older branches and it seemed to work fine until I restarted my simulator. Then I realized that the new code was using an undefined `View.propTypes` which has been moved to `ViewPropTypes`.